### PR TITLE
fix(workspace): :bug: renovate config validator task will succeed even if not installed

### DIFF
--- a/packages/workspace/src/generators/renovate/renovate-config-validator-task.spec.ts
+++ b/packages/workspace/src/generators/renovate/renovate-config-validator-task.spec.ts
@@ -20,7 +20,9 @@ describe('@nx-squeezer/workspace renovateConfigValidatorTask', () => {
 
     expect(renovateConfigValidatorTask(tree)).toBeFalsy();
 
-    expect(exec).toHaveBeenCalledWith('npx', ['renovate-config-validator'], { cwd: '/virtual' });
+    expect(exec).toHaveBeenCalledWith('npx', ['--package', 'renovate', '-c', 'renovate-config-validator'], {
+      cwd: '/virtual',
+    });
   });
 
   it('should return false', () => {

--- a/packages/workspace/src/generators/renovate/renovate-config-validator-task.ts
+++ b/packages/workspace/src/generators/renovate/renovate-config-validator-task.ts
@@ -4,13 +4,16 @@ import { exec } from '../lib';
 
 export function renovateConfigValidatorTask(tree: Tree): boolean {
   console.log(`Validating Renovate configuration...`);
-  const { output, error } = exec('npx', ['renovate-config-validator'], {
+  const { output, error } = exec('npx', ['--package', 'renovate', '-c', 'renovate-config-validator'], {
     cwd: tree.root,
   });
 
   if (error != null) {
+    console.error(error);
     return false;
   }
+
+  console.log(output);
 
   return output.includes(`Config validated successfully`);
 }


### PR DESCRIPTION
It now uses a full command that does not rely on having the package installed locally. Taken from https://github.com/rinchsan/renovate-config-validator/blob/main/src/main.ts

Closes #259