### PR TITLE
fix(workspace): :bug: configure prettier override for html

### DIFF
--- a/packages/workspace-e2e/tests/workspace.spec.ts
+++ b/packages/workspace-e2e/tests/workspace.spec.ts
@@ -78,6 +78,14 @@ describe('@nx-squeezer/workspace e2e', () => {
         trailingComma: 'es5',
         bracketSpacing: true,
         arrowParens: 'always',
+        overrides: [
+          {
+            files: '*.html',
+            options: {
+              parser: 'html',
+            },
+          },
+        ],
       });
     });
   });

--- a/packages/workspace/.eslintrc.json
+++ b/packages/workspace/.eslintrc.json
@@ -18,7 +18,7 @@
       "rules": {}
     },
     {
-      "files": ["./package.json", "./generators.json", "./executors.json"],
+      "files": ["./package.json", "./generators.json", "./executors.json", "./migrations.json"],
       "parser": "jsonc-eslint-parser",
       "rules": {
         "@nrwl/nx/nx-plugin-checks": "error"

--- a/packages/workspace/jest.config.ts
+++ b/packages/workspace/jest.config.ts
@@ -12,4 +12,12 @@ export default {
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../coverage/packages/workspace',
   coverageReporters: ['lcov'],
+  coverageThreshold: {
+    global: {
+      branches: 100,
+      functions: 100,
+      lines: 100,
+      statements: 100,
+    },
+  },
 };

--- a/packages/workspace/migrations.json
+++ b/packages/workspace/migrations.json
@@ -1,0 +1,10 @@
+{
+  "generators": {
+    "add-html-override-to-prettier-config": {
+      "version": "1.1.0",
+      "description": "Add html override to prettier config so that eslint can successfully parse html files",
+      "cli": "nx",
+      "implementation": "./src/migrations/add-html-override-to-prettier-config/add-html-override-to-prettier-config"
+    }
+  }
+}

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -52,5 +52,8 @@
     "@schemastore/prettierrc": "^0.0.9",
     "@schemastore/tsconfig": "^0.0.9",
     "@types/which": "^2.0.1"
+  },
+  "nx-migrations": {
+    "migrations": "./migrations.json"
   }
 }

--- a/packages/workspace/project.json
+++ b/packages/workspace/project.json
@@ -32,6 +32,11 @@
             "input": "./packages/workspace",
             "glob": "executors.json",
             "output": "."
+          },
+          {
+            "input": "./packages/workspace",
+            "glob": "migrations.json",
+            "output": "."
           }
         ]
       }
@@ -44,7 +49,8 @@
           "packages/workspace/**/*.ts",
           "packages/workspace/generators.json",
           "packages/workspace/executors.json",
-          "packages/workspace/package.json"
+          "packages/workspace/package.json",
+          "packages/workspace/migrations.json"
         ]
       }
     },

--- a/packages/workspace/src/generators/lib/tasks/noop.spec.ts
+++ b/packages/workspace/src/generators/lib/tasks/noop.spec.ts
@@ -1,0 +1,7 @@
+import { noopTask } from './noop-task';
+
+describe('@nx-squeezer/workspace noopTask', () => {
+  it('should execute the task', () => {
+    expect(noopTask()).toBeFalsy();
+  });
+});

--- a/packages/workspace/src/generators/prettier/prettier-default-config.ts
+++ b/packages/workspace/src/generators/prettier/prettier-default-config.ts
@@ -7,4 +7,12 @@ export const prettierDefaultConfig: Exclude<SchemaForPrettierrc, string> = {
   trailingComma: 'es5',
   bracketSpacing: true,
   arrowParens: 'always',
+  overrides: [
+    {
+      files: '*.html',
+      options: {
+        parser: 'html',
+      },
+    },
+  ],
 };

--- a/packages/workspace/src/migrations/add-html-override-to-prettier-config/add-html-override-to-prettier-config.spec.ts
+++ b/packages/workspace/src/migrations/add-html-override-to-prettier-config/add-html-override-to-prettier-config.spec.ts
@@ -1,0 +1,58 @@
+import { readJson, Tree, writeJson } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+
+import addHtmlOverrideToPrettierConfig from './add-html-override-to-prettier-config';
+import { prettierConfigFile, prettierConfigJsonFile } from '../../generators';
+
+const htmlOverride = {
+  files: '*.html',
+  options: {
+    parser: 'html',
+  },
+};
+
+describe('@nx-squeezer/workspace add html override to prettier config migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+    tree.delete(prettierConfigFile);
+    jest.spyOn(console, 'log').mockImplementation(() => null);
+  });
+
+  it('should run successfully', async () => {
+    await addHtmlOverrideToPrettierConfig(tree);
+  });
+
+  it('should add overrides configuration if it did not exist', async () => {
+    writeJson(tree, prettierConfigJsonFile, {});
+
+    await addHtmlOverrideToPrettierConfig(tree);
+
+    expect(readJson(tree, prettierConfigJsonFile)).toStrictEqual({
+      overrides: [htmlOverride],
+    });
+  });
+
+  it('should add overrides configuration if it existed', async () => {
+    writeJson(tree, prettierConfigJsonFile, { overrides: [] });
+
+    await addHtmlOverrideToPrettierConfig(tree);
+
+    expect(readJson(tree, prettierConfigJsonFile)).toStrictEqual({
+      overrides: [htmlOverride],
+    });
+  });
+
+  it('should not add overrides configuration if already present', async () => {
+    writeJson(tree, prettierConfigJsonFile, {
+      overrides: [htmlOverride],
+    });
+
+    await addHtmlOverrideToPrettierConfig(tree);
+
+    expect(readJson(tree, prettierConfigJsonFile)).toStrictEqual({
+      overrides: [htmlOverride],
+    });
+  });
+});

--- a/packages/workspace/src/migrations/add-html-override-to-prettier-config/add-html-override-to-prettier-config.ts
+++ b/packages/workspace/src/migrations/add-html-override-to-prettier-config/add-html-override-to-prettier-config.ts
@@ -1,0 +1,30 @@
+import { formatFiles, readJson, Tree, writeJson } from '@nrwl/devkit';
+import { SchemaForPrettierrc } from '@schemastore/prettierrc';
+
+import { prettierConfigJsonFile } from '../../generators';
+
+export default async function addHtmlOverrideToPrettierConfig(tree: Tree) {
+  if (!tree.exists(prettierConfigJsonFile)) {
+    return;
+  }
+
+  const prettierConfig = readJson<Exclude<SchemaForPrettierrc, string>>(tree, prettierConfigJsonFile);
+  const overrides = prettierConfig.overrides ?? [];
+  if (overrides.find((rule) => rule.files === '*.html') != null) {
+    return;
+  }
+
+  prettierConfig.overrides = [
+    ...overrides,
+    {
+      files: '*.html',
+      options: {
+        parser: 'html',
+      },
+    },
+  ];
+
+  writeJson(tree, prettierConfigJsonFile, prettierConfig);
+
+  await formatFiles(tree);
+}


### PR DESCRIPTION
Adds the html parser to prettier configuration so that it works well with ESLint

Closes #357