### PR TITLE
fix(workspace): fix eslint for e2e-projects

### DIFF
--- a/packages/ng-async-injector-app/.eslintrc.json
+++ b/packages/ng-async-injector-app/.eslintrc.json
@@ -32,7 +32,7 @@
     {
       "files": ["*.ts", "*.tsx"],
       "parserOptions": {
-        "project": ["packages/ng-async-injector-app/tsconfig.*?.json"]
+        "project": ["packages/ng-async-injector-app/tsconfig*.json"]
       }
     }
   ]

--- a/packages/ng-async-injector/.eslintrc.json
+++ b/packages/ng-async-injector/.eslintrc.json
@@ -32,7 +32,7 @@
     {
       "files": ["*.ts", "*.tsx"],
       "parserOptions": {
-        "project": ["packages/ng-async-injector/tsconfig.*?.json"]
+        "project": ["packages/ng-async-injector/tsconfig*.json"]
       }
     }
   ]

--- a/packages/workspace-e2e/.eslintrc.json
+++ b/packages/workspace-e2e/.eslintrc.json
@@ -10,7 +10,7 @@
       "files": ["*.ts", "*.tsx"],
       "rules": {},
       "parserOptions": {
-        "project": ["packages/workspace-e2e/tsconfig.*?.json"]
+        "project": ["packages/workspace-e2e/tsconfig*.json"]
       }
     },
     {

--- a/packages/workspace-e2e/tests/workspace.spec.ts
+++ b/packages/workspace-e2e/tests/workspace.spec.ts
@@ -51,7 +51,7 @@ describe('@nx-squeezer/workspace e2e', () => {
   // For this reason, we recommend each suite only
   // consumes 1 workspace. The tests should each operate
   // on a unique project in the workspace, such that they
-  // are not dependant on one another.
+  // are not dependent on one another.
   beforeAll(async () => {
     ensureNxProject('@nx-squeezer/workspace', 'dist/packages/workspace');
   });

--- a/packages/workspace/.eslintrc.json
+++ b/packages/workspace/.eslintrc.json
@@ -10,7 +10,7 @@
       "files": ["*.ts", "*.tsx"],
       "rules": {},
       "parserOptions": {
-        "project": ["packages/workspace/tsconfig.*?.json"]
+        "project": ["packages/workspace/tsconfig*.json"]
       }
     },
     {

--- a/packages/workspace/src/generators/eslint/generator.spec.ts
+++ b/packages/workspace/src/generators/eslint/generator.spec.ts
@@ -89,7 +89,7 @@ describe('@nx-squeezer/workspace eslint generator', () => {
       expect(eslintConfig.overrides?.[0]).toStrictEqual(typescriptRule);
       expect(readEsLintConfig(tree, `libs/lib1/${eslintConfigFile}`).overrides?.[0]).toStrictEqual({
         files: ['*.ts', '*.tsx'],
-        parserOptions: { project: ['libs/lib1/tsconfig.*?.json'] },
+        parserOptions: { project: ['libs/lib1/tsconfig*.json'] },
       });
     },
     timeout
@@ -108,7 +108,7 @@ describe('@nx-squeezer/workspace eslint generator', () => {
       expect(eslintConfig.overrides?.[0]).toStrictEqual(deprecationRule);
       expect(readEsLintConfig(tree, `libs/lib1/${eslintConfigFile}`).overrides?.[0]).toStrictEqual({
         files: ['*.ts', '*.tsx'],
-        parserOptions: { project: ['libs/lib1/tsconfig.*?.json'] },
+        parserOptions: { project: ['libs/lib1/tsconfig*.json'] },
       });
     },
     timeout

--- a/packages/workspace/src/generators/eslint/generator.ts
+++ b/packages/workspace/src/generators/eslint/generator.ts
@@ -103,7 +103,7 @@ function addParserOptionsToProjects(tree: Tree) {
   updateEsLintProjectConfig(tree, (project) => ({
     files: ['*.ts', '*.tsx'],
     parserOptions: {
-      project: [joinNormalize(project.root, 'tsconfig.*?.json')],
+      project: [joinNormalize(project.root, 'tsconfig*.json')],
     },
   }));
 }


### PR DESCRIPTION
- by being less strict with the parser options

closes: https://github.com/nx-squeezer/squeezer/issues/391