### PR TITLE
feat(workspace): :sparkles: configure renovate to widen dependencies

### DIFF
--- a/default.json
+++ b/default.json
@@ -12,6 +12,7 @@
     ":semanticCommits",
     "schedule:weekends",
     "github>whitesource/merge-confidence:beta",
+    "local>nx-squeezer/squeezer:widenRangeLibraryDeps",
     "local>nx-squeezer/squeezer:gitmoji",
     "local>nx-squeezer/squeezer:npm",
     "local>nx-squeezer/squeezer:groupAllNonMajor",

--- a/packages/workspace/README.md
+++ b/packages/workspace/README.md
@@ -267,6 +267,17 @@ This [preset](https://github.com/nx-squeezer/squeezer/blob/main/maintenance.json
 
 </details>
 
+<details>
+  <summary>Widen Range for Library Dependencies</summary>
+
+This [preset](https://github.com/nx-squeezer/squeezer/blob/main/widenRangeLibraryDeps.json) causes Renovate to _not_ update libraries' `package.json`, only the root `package.json` will be updated for minor and patch versions. This has the purpose of keeping libraries with a wider compatibility range, within the last major version. This is the recommended configuration for library authors.
+
+```json
+"extends": ["github>@nx-squeezer/squeezer:widenRangeLibraryDeps"]
+```
+
+</details>
+
 ## [tsconfig](src/generators/tsconfig/README.md)
 
 Setup command:

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -35,16 +35,16 @@
   "schematics": "./schematics.json",
   "executors": "./executors.json",
   "dependencies": {
-    "@nrwl/devkit": "^15.6.3",
-    "node-fetch-commonjs": "^3.2.4",
-    "yaml": "^2.2.1"
+    "@nrwl/devkit": "^15.0.0",
+    "node-fetch-commonjs": "^3.0.0",
+    "yaml": "^2.0.0"
   },
   "peerDependencies": {
-    "@commitlint/cli": "^17.4.2",
-    "@commitlint/config-conventional": "^17.4.2",
-    "husky": "^8.0.3",
-    "lint-staged": "^13.1.0",
-    "prettier": "^2.8.3",
+    "@commitlint/cli": "^17.0.0",
+    "@commitlint/config-conventional": "^17.0.0",
+    "husky": "^8.0.0",
+    "lint-staged": "^13.0.0",
+    "prettier": "^2.8.0",
     "renovate": "^34.120.0"
   },
   "devDependencies": {
@@ -52,7 +52,7 @@
     "@schemastore/package": "^0.0.6",
     "@schemastore/prettierrc": "^0.0.9",
     "@schemastore/tsconfig": "^0.0.9",
-    "@types/which": "^2.0.1"
+    "@types/which": "^2.0.0"
   },
   "nx-migrations": {
     "migrations": "./migrations.json"

--- a/packages/workspace/src/generators/renovate/README.md
+++ b/packages/workspace/src/generators/renovate/README.md
@@ -133,3 +133,14 @@ This [preset](https://github.com/nx-squeezer/squeezer/blob/main/maintenance.json
 ```
 
 </details>
+
+<details>
+  <summary>Widen Range for Library Dependencies</summary>
+
+This [preset](https://github.com/nx-squeezer/squeezer/blob/main/widenRangeLibraryDeps.json) causes Renovate to _not_ update libraries' `package.json`, only the root `package.json` will be updated for minor and patch versions. This has the purpose of keeping libraries with a wider compatibility range, within the last major version. This is the recommended configuration for library authors.
+
+```json
+"extends": ["github>@nx-squeezer/squeezer:widenRangeLibraryDeps"]
+```
+
+</details>

--- a/packages/workspace/src/generators/renovate/presets/widenRangeLibraryDeps.json
+++ b/packages/workspace/src/generators/renovate/presets/widenRangeLibraryDeps.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["dependencies", "peerDependencies", "optionalDependencies", "devDependencies"],
+      "matchUpdateTypes": ["minor", "patch", "bump"],
+      "excludePaths": ["package.json"],
+      "enabled": false
+    }
+  ]
+}

--- a/packages/workspace/src/generators/renovate/renovate.ts
+++ b/packages/workspace/src/generators/renovate/renovate.ts
@@ -11,5 +11,6 @@ export const renovatePresets = [
   'maintenance.json',
   'npm.json',
   'nrwlWorkspace.json',
+  'widenRangeLibraryDeps.json',
 ];
 export const renovateBranch = 'renovate-github/**';

--- a/widenRangeLibraryDeps.json
+++ b/widenRangeLibraryDeps.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["dependencies", "peerDependencies", "optionalDependencies", "devDependencies"],
+      "matchUpdateTypes": ["minor", "patch", "bump"],
+      "excludePaths": ["package.json"],
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
Dependencies on libraries' pacakge.json won't be updated for minor or patch versions, providing a wider compatibility range.

Closes #432