### PR TITLE
fix(renovate): :bug: don't update tslib

### DIFF
--- a/nxMonorepo.json
+++ b/nxMonorepo.json
@@ -4,15 +4,24 @@
     {
       "groupName": "Nx monorepo",
       "matchManagers": ["npm"],
-      "matchPackagePatterns": ["^tslib", "^ts-node", "^zone\\.js", "^cypress$", "^jest", "@types/jest", "^ts-jest"],
+      "matchPackagePatterns": [
+        "^tslib",
+        "^ts-node",
+        "^zone\\.js",
+        "^cypress$",
+        "^jest",
+        "@types/jest",
+        "^ts-jest",
+        "^rxjs"
+      ],
       "matchUpdateTypes": ["major"],
       "enabled": false
     },
     {
       "groupName": "Nx monorepo",
       "matchManagers": ["npm"],
-      "matchPackagePatterns": ["^typescript"],
-      "matchUpdateTypes": ["major", "minor"],
+      "matchPackagePatterns": ["^tslib"],
+      "matchUpdateTypes": ["major", "minor", "patch"],
       "enabled": false
     },
     {

--- a/packages/renovate/src/generators/renovate/presets/nxMonorepo.json
+++ b/packages/renovate/src/generators/renovate/presets/nxMonorepo.json
@@ -4,15 +4,24 @@
     {
       "groupName": "Nx monorepo",
       "matchManagers": ["npm"],
-      "matchPackagePatterns": ["^tslib", "^ts-node", "^zone\\.js", "^cypress$", "^jest", "@types/jest", "^ts-jest"],
+      "matchPackagePatterns": [
+        "^tslib",
+        "^ts-node",
+        "^zone\\.js",
+        "^cypress$",
+        "^jest",
+        "@types/jest",
+        "^ts-jest",
+        "^rxjs"
+      ],
       "matchUpdateTypes": ["major"],
       "enabled": false
     },
     {
       "groupName": "Nx monorepo",
       "matchManagers": ["npm"],
-      "matchPackagePatterns": ["^typescript"],
-      "matchUpdateTypes": ["major", "minor"],
+      "matchPackagePatterns": ["^tslib"],
+      "matchUpdateTypes": ["major", "minor", "patch"],
       "enabled": false
     },
     {


### PR DESCRIPTION
Build executors ship tslib without open range, so updating it results in version mismatches. This dependency will automatically be updated by the build library.